### PR TITLE
Create conv__currency - convert currency between iso codes and output string

### DIFF
--- a/Formulas/conv__currency - convert currency between iso codes and output string.js
+++ b/Formulas/conv__currency - convert currency between iso codes and output string.js
@@ -1,0 +1,15 @@
+skuid.formula.Formula (
+    'curr',
+    
+    function (amount,defaultiso,useriso,roundto) { 
+        convertedcurrency = skuid.utils.convertCurrency(amount,defaultiso,useriso);
+        roundby = roundto || 1;
+        roundedcurrency = Math.round(convertedcurrency/roundby) * roundby;
+        currobj = {recordCurrency: useriso};
+        return skuid.currency.getDisplayValue(roundedcurrency, currobj);
+  },{
+    namespace: 'conv',
+    numArgs : 4,
+    returnType : 'string'
+  }
+);


### PR DESCRIPTION
This should be adding a new formula file that takes in a currency amount then converts it between iso codes and spits out a properly formatted string. Use case is for KPIs in multicurrency orgs where you just want to show end user currency, not USD 34561 (CAD 43000).