### PR TITLE
Add default state to formulas, use getRows() consistently

### DIFF
--- a/experiments/formulas/math/avg.js
+++ b/experiments/formulas/math/avg.js
@@ -7,8 +7,10 @@ skuid.formula.Formula(
 	'avg',
 	function (modelname, fieldname) {
 		var model = skuid.$M(modelname),
-			arr = model.data,
+			arr = model.getRows(),
 			initialValue = 0;
+
+		if (arr.length === 0) return 0;
 
 		var sum = arr.reduce(function (accumulator, currentValue) {
 			return accumulator + currentValue[fieldname];

--- a/experiments/formulas/math/avg.js
+++ b/experiments/formulas/math/avg.js
@@ -1,6 +1,6 @@
 // Average model column
 // avg field
-// expects input of math__avg('ModelName','FieldId') for the corresponding model and field you want to average
+// expects input of math__avg('ModelName','AvgFieldId') for the corresponding model and field you want to average
 // Matt Davis
 
 skuid.formula.Formula(
@@ -16,6 +16,7 @@ skuid.formula.Formula(
 
 		return (sum / arr.length);
 	}, {
+		defaultState: 'math__avg("ModelName","AvgFieldId")',
 		namespace: 'math',
 		numArgs: 2,
 		returnType: 'number'

--- a/experiments/formulas/math/avgif.js
+++ b/experiments/formulas/math/avgif.js
@@ -8,18 +8,20 @@ skuid.formula.Formula(
 	'avgif',
 	function (modelname, fieldname, iffield, ifvalue) {
 		var model = skuid.$M(modelname),
-			arr = model.data,
+			arr = model.getRows(),
 			initialValue = 0;
+
+		if (arr.length === 0) return 0;
 
 		function filterByField(item) {
 			return item[iffield] === ifvalue;
 		}
 
-		var filtarr = arr.filter(filterByField);
-
-		var sumif = filtarr.reduce(function (accumulator, currentValue) {
-			return accumulator + currentValue[fieldname];
-		}, initialValue);
+		var sumif = arr
+			.filter(filterByField);
+			.reduce(function (accumulator, currentValue) {
+				return accumulator + currentValue[fieldname];
+			}, initialValue);
 
 		return (sumif / filtarr.length);
 	}, {

--- a/experiments/formulas/math/avgif.js
+++ b/experiments/formulas/math/avgif.js
@@ -1,6 +1,6 @@
 // Conditional model column average
 // average conditionally
-// expects input of math__avgif('ModelName','FieldId', 'ConiditionFieldId','ConditionValue') for the corresponding model and field you want to sum conditionally
+// expects input of math__avgif('ModelName','AvgFieldId', 'IfFieldId','IfValue') for the corresponding model and field you want to average conditionally
 // example: I want to find the average Oppty Amount where the Stage is Commit -> math__avgif('Oppty','Amount','StageName','Commit')
 // Matt Davis
 
@@ -23,6 +23,7 @@ skuid.formula.Formula(
 
 		return (sumif / filtarr.length);
 	}, {
+		defaultState: 'math__avgif("ModelName","AvgFieldId", "IfFieldId", "IfValue")',
 		namespace: 'math',
 		numArgs: 4,
 		returnType: 'number'

--- a/experiments/formulas/math/countif.js
+++ b/experiments/formulas/math/countif.js
@@ -1,6 +1,6 @@
 // Conditional model row counter
 // average conditionally
-// expects input of math__avgif('ModelName','FieldId', 'ConiditionFieldId','ConditionValue') for the corresponding model and field you want to sum conditionally
+// expects input of math__countif('ModelName','FieldId', 'ConiditionFieldId','ConditionValue') for the corresponding model and field you want to sum conditionally
 // example: I want to find the average Oppty Amount where the Stage is Commit -> math__avgif('Oppty','Amount','StageName','Commit')
 // Matt Davis
 
@@ -8,16 +8,15 @@ skuid.formula.Formula(
 	'countif',
 	function (modelname, fieldname, iffield, ifvalue) {
 		var model = skuid.$M(modelname),
-			arr = model.data;
+			arr = model.getRows();
 
 		function filterByField(item) {
 			return item[iffield] === ifvalue;
 		}
 
-		var filtarr = arr.filter(filterByField);
-
-		return (filtarr.length);
+		return arr.filter(filterByField).length;
 	}, {
+		defaultState: 'math__countif("ModelName","CountFieldId", "IfFieldId", "IfValue")',
 		namespace: 'math',
 		numArgs: 4,
 		returnType: 'number'

--- a/experiments/formulas/math/sum.js
+++ b/experiments/formulas/math/sum.js
@@ -1,6 +1,6 @@
 // Sum model column
 // sum field
-// expects input of math__sum('ModelName','FieldId') for the corresponding model and field you want to sum
+// expects input of math__sum('ModelName','SumFieldId') for the corresponding model and field you want to sum
 // Matt Davis
 
 skuid.formula.Formula(
@@ -14,6 +14,7 @@ skuid.formula.Formula(
 			return accumulator + currentValue[fieldname];
 		}, initialValue);
 	}, {
+		defaultState: 'math__sum("ModelName","SumFieldId")',
 		namespace: 'math',
 		numArgs: 2,
 		returnType: 'number'

--- a/experiments/formulas/math/sum.js
+++ b/experiments/formulas/math/sum.js
@@ -7,7 +7,7 @@ skuid.formula.Formula(
 	'sum',
 	function (modelname, fieldname) {
 		var model = skuid.$M(modelname),
-			arr = model.data,
+			arr = model.getRows(),
 			initialValue = 0;
 
 		return arr.reduce(function (accumulator, currentValue) {

--- a/experiments/formulas/math/sumif.js
+++ b/experiments/formulas/math/sumif.js
@@ -21,6 +21,7 @@ skuid.formula.Formula(
 			return accumulator + currentValue[fieldname];
 		}, initialValue);
 	}, {
+		defaultState: 'math__sumif("ModelName","SumFieldId","IfFieldId","IfValue")',
 		namespace: 'math',
 		numArgs: 4,
 		returnType: 'number'

--- a/experiments/formulas/math/sumif.js
+++ b/experiments/formulas/math/sumif.js
@@ -8,7 +8,7 @@ skuid.formula.Formula(
 	'sumif',
 	function (modelname, fieldname, iffield, ifvalue) {
 		var model = skuid.$M(modelname),
-			arr = model.data,
+			arr = model.getRows(),
 			initialValue = 0;
 
 		function filterByField(item) {


### PR DESCRIPTION
# Summary of Changes

- Adds a `defaultState` for all formulas to assist in use of the formulas in the Page Composer.
- Switch to use of `model.getRows()` API instead of direct reference of .data, this is a best practice.