### PR TITLE
Allow use of ES6, ES7 in Javascript files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
 		"arguments": false
 	},
 	"parserOptions": {  
-		"ecmaVersion": 5
+		"ecmaVersion": 7
 	},
 	"plugins": [
 		"json"

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ sfdx-project.json
 *.sublime-project
 *.sublime-settings
 *.sublime-workspace
-dmc_config.json
-force.json
+*.code-workspace
 node_modules
 npm-debug.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,6 @@ We do ask that your submission follow our general code and structure guidelines:
 
   - If you’ll be using variables that are not defined in the file, you may [set your globals in a comment at the top of your file](https://eslint.org/docs/user-guide/configuring#specifying-globals), but only use this when appropriate.
   - If you have a 3rd-party library that you are using in a component pack, we prefer that you reference that library via an external reference in your component pack manifest files, rather than including the library's minified JS locally in your component pack, unless the library is fairly small.
-  - We recommend using ES5 for maximum compatibility among browsers.
 
 ## Who owns the code I contribute?
 


### PR DESCRIPTION
# Summary of Changes
- Allows use of ES6 and ES7 features within any JavaScript file that is contributed, e.g. variables can now be declared using `let` or `const` and builds should not fail.