### PR TITLE
Allow global returns since Skuid snippets are often wrapped in functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,8 +8,11 @@
 		"skuid": false,
 		"arguments": false
 	},
-	"parserOptions": {  
-		"ecmaVersion": 7
+	"parserOptions": {
+		"ecmaVersion": 7,
+    "ecmaFeatures": {
+      "globalReturn": true
+    }
 	},
 	"plugins": [
 		"json"
@@ -32,8 +35,8 @@
 			"always"
 		],
 		"no-eval": [
-			"error"    
-		], 
+			"error"
+		],
 		"no-new-func": [
 			"error"
 		]


### PR DESCRIPTION
Due to the nature of Skuid snippets, code in this repo will often look like they have `return` statements in the "global" scope, but they are actually wrapped in functions when implemented in Skuid. This ESLint config option therefore is useful for the kind of code we'll have here.


@JerCarpenter  This will helps [the (non)issue re: `return`](https://github.com/skuid/skuid-labs/pull/59#discussion_r520856300) on your SmartAdopt PR. 


Sidenote: Also minor clean up of whitespace.