### PR TITLE
added Favorites Endpoint to SFDC Rest examples

### DIFF
--- a/experiments/dataSources/SalesforceREST/readme.md
+++ b/experiments/dataSources/SalesforceREST/readme.md
@@ -6,7 +6,7 @@ Don't worry! Salesforce provides a rich array of APIs that provide access to thi
 Examples of this data include: 
 
 * Access to [Data.com search](https://developer.salesforce.com/docs/atlas.en-us.datadotcom_api_dev_guide.meta/datadotcom_api_dev_guide/datadotcom_api_dev_guide_intro.htm).
-* Access to the [interface API](https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_get_started.htm)-  like creating a model of field pick-list values, or retrieving the current user's Favorite records. 
+* Access to the [interface API](https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_get_started.htm)-  like creating a model of field picklist values or retrieving the current user's Favorite records. 
 * Access to many [setup objects](https://developer.salesforce.com/docs/atlas.en-us.220.0.object_reference.meta/object_reference/sforce_api_objects_concepts.htm) not exposed as objects to Skuid.  
 
 


### PR DESCRIPTION
A small change to the SFDC Rest Examples to describe getting to users Favorite records. 

Also removing references to REPORTING API - cuz it was impossible to use without code. 